### PR TITLE
Update CAPZ app version to newer alpha with private cluster deletion fixes

### DIFF
--- a/flux-manifests/cluster-api-provider-azure.yaml
+++ b/flux-manifests/cluster-api-provider-azure.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api-provider-azure
-app_version: 1.9.0-alpha.4
+app_version: 1.9.0-alpha.5
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2528

### What does this PR do?

This PR update CAPZ app version to newer alpha with private cluster deletion fixes