### PR TITLE
Support Autoscaling for MachinePools

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.9.0
+app_version: 1.11.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
In order to align with the PR https://github.com/giantswarm/capa-app-collection/pull/35, we should update CAPI to 1.4.0.

Roadmap Issue: https://github.com/giantswarm/roadmap/issues/2691
Cluster API App Release: https://github.com/giantswarm/cluster-api-app/releases/tag/v1.11.0
Upstream Release: https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.4.0


### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)