### PR TITLE
Update trivy to 0.9.0

### DIFF
--- a/flux-manifests/trivy.yaml
+++ b/flux-manifests/trivy.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: trivy
-app_version: 0.7.1
+app_version: 0.9.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
trivy is out-dated here. capz-app-collection was added to its ci recently. see https://github.com/giantswarm/trivy-app/pull/114