### PR TITLE
revert pmo to previous version

### DIFF
--- a/flux-manifests/prometheus-meta-operator.yaml
+++ b/flux-manifests/prometheus-meta-operator.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: monitoring
 app_name: prometheus-meta-operator
-app_version: 4.67.0
+app_version: 4.66.1
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
PMO is failing due to an error in the latest release
