### PR TITLE
Upgrade CAPZ to 1.12.4-gs1

### DIFF
--- a/flux-manifests/cluster-api-provider-azure.yaml
+++ b/flux-manifests/cluster-api-provider-azure.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api-provider-azure
-app_version: '1.9.0-alpha.9'
+app_version: '1.12.4-gs1'
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
All MCs and WCs are upgraded to the latest cluster-azure. https://github.com/giantswarm/giantswarm/issues/31248

Now we can release this version to release the multi-subscription feature.
https://github.com/giantswarm/roadmap/issues/3294